### PR TITLE
Tweaking API and adding some initial custom styling

### DIFF
--- a/src/Sort.svelte
+++ b/src/Sort.svelte
@@ -7,7 +7,7 @@
 </script>
 
 <script>
-  import { createEventDispatcher } from "svelte";
+  import { createEventDispatcher, getContext } from "svelte";
   const dispatch = createEventDispatcher();
 
   export let dir = "none";
@@ -20,14 +20,15 @@
   };
 
   function onClick(e) {
-    const detail = { originalEvent: e, key, dir: "asc" };
+    const {getRows} = getContext("filteredRows");
+    const detail = { originalEvent: e, key, dir: "asc", rows: getRows() };
 
     if (dir !== "desc") {
       detail.dir = "desc";
     }
 
     dispatch("sort", detail);
-
+    
     if (detail.returnValue !== false) {
       dir = detail.dir;
     }

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -19,6 +19,13 @@
 </script>
 
 <script>
+  
+  export let searchStyle = '';
+  // theming variables:
+  export let searchFloat = 'left';
+  export let searchWidth = '100%';
+  export let searchMarginBottom = '1em';
+
   export let loading = false;
   export let page = 0;
   export let pageSize = 10;
@@ -61,8 +68,7 @@
 
     for (let i in row) {
       if (
-        row[i]
-          .toString()
+        String(row[i])
           .toLowerCase()
           .indexOf(text) > -1
       ) {
@@ -72,6 +78,13 @@
 
     return false;
   }
+
+  $: searchStyle = `
+    --float:${searchFloat};
+    --width:${searchWidth};
+    --margin-bottom: ${searchMarginBottom};
+    ${style}
+  `;
 </script>
 
 <style>
@@ -153,7 +166,7 @@
 </style>
 
 <slot name="top">
-  <div style="float:left;width:100%;margin-bottom: 1em;">
+  <div style={searchStyle}>
     <Search on:search={onSearch} />
   </div>
 </slot>

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -19,36 +19,39 @@
 </script>
 
 <script>
-  
+  import { setContext } from "svelte";
+
   export let searchStyle = '';
   // theming variables:
   export let searchFloat = 'left';
   export let searchWidth = '100%';
   export let searchMarginBottom = '1em';
   export let style = '';
-  
+  export let rows;
   export let loading = false;
   export let page = 0;
   export let pageSize = 10;
   export let responsive = true;
-  export let rows;
+  export let alteredRows;
   export let labels = {
     empty: "No records available",
     loading: "Loading data",
     ...globalLabels
   };
-
+  setContext("filteredRows", {getRows:()=>filteredRows});
+  
   let filteredRows;
   let visibleRows;
   let pageCount = 0;
   let buttons = [-2, -1, 0, 1, 2];
 
-  $: filteredRows = rows;
+  $: filteredRows = alteredRows;
   $: currentFirstItemIndex = page * pageSize;
   $: visibleRows = filteredRows.slice(
     currentFirstItemIndex,
     currentFirstItemIndex + pageSize
   );
+
 
   function onPageChange(event) {
     page = event.detail;
@@ -58,9 +61,9 @@
     page = 0;
 
     if (event.detail.length === 0) {
-      filteredRows = rows;
+      alteredRows = rows;
     } else {
-      filteredRows = rows.filter(r => filter(r, event.detail));
+      filteredRows = alteredRows.filter(r => filter(r, event.detail));
     }
   }
 
@@ -195,7 +198,7 @@
       </tr>
 	</tbody>
   {:else}
-    <slot rows={visibleRows} />
+    <slot alteredRows={visibleRows} />
   {/if}
   <slot name="foot" />
 </table>

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -25,7 +25,8 @@
   export let searchFloat = 'left';
   export let searchWidth = '100%';
   export let searchMarginBottom = '1em';
-
+  export let style = '';
+  
   export let loading = false;
   export let page = 0;
   export let pageSize = 10;


### PR DESCRIPTION
**Styling**
I needed to style a few of the components and I could get to everything with CSS selectors except for the search box. 
6eDesign had proposed a very good solution in their svelte-calendar component where they added a new style prop to allow for custom styling to be implemented. However, my implementation of it is very primitive, I've only added a prop to style the search box but we can expand it to cover more of the table.

**Sorting Filtered Rows**
Additionally, I've added the functionality for sorting to be applied to filteredRows since sorting currently only affected the initial set of rows which looked as if the table was performing incorrectly. I'm sending the filtered rows to the sorting component via the Context API and thus adding them to the sorting event's details. This changes how sorting occurs where the rows are provided in the event's details and those are sorted.
In order to not erase all of the tables data in case of an empty search result, I needed to repurpose the `row` prop and add an additional prop `alteredRows`. The rows prop will hold the static data, this allows for the table to recover from an empty search result, the `alteredRows` prop is changed when sorting occurs allowing for search results to be sorted.

_To summarize_
**Adding the custom styling prop for search**

`<Table  style="display:flex; justify-content:end; padding-bottom:1em;" . . . `

**Adding filtered rows to sorting**

```
<Table  . . .  rows={products} alteredRows={alteredRows}  . . . 

function onSortString({ detail: { dir, key, rows } }) {
        alteredRows = sortString(rows, dir, key);
}
```

